### PR TITLE
Add dark mode toggle to homepage (PER-31)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,33 @@
-import React from 'react';
-import { Building2, Users2, BarChart3, Globe2 } from 'lucide-react';
+import React, { useState, useEffect } from 'react';
+import { Building2, Users2, BarChart3, Globe2, Sun, Moon } from 'lucide-react';
 
 function App() {
+  const [darkMode, setDarkMode] = useState(false);
+
+  // Apply dark mode class to body
+  useEffect(() => {
+    if (darkMode) {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }, [darkMode]);
+
   return (
-    <div className="min-h-screen bg-white">
+    <div className={`min-h-screen ${darkMode ? 'bg-gray-900' : 'bg-white'} transition-colors duration-200`}>
+      {/* Dark Mode Toggle */}
+      <button
+        onClick={() => setDarkMode(!darkMode)}
+        className="fixed top-4 right-4 p-2 rounded-full bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+        aria-label="Toggle dark mode"
+      >
+        {darkMode ? (
+          <Sun className="w-6 h-6 text-yellow-500" />
+        ) : (
+          <Moon className="w-6 h-6 text-gray-700" />
+        )}
+      </button>
+
       {/* Hero Section */}
       <section className="relative h-screen">
         <div className="absolute inset-0">
@@ -40,13 +64,13 @@ function App() {
       </section>
 
       {/* Features Section */}
-      <section className="py-20 bg-gray-50">
+      <section className={`py-20 ${darkMode ? 'bg-gray-800' : 'bg-gray-50'} transition-colors duration-200`}>
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h2 className="text-3xl font-bold text-gray-900 sm:text-4xl">
+            <h2 className={`text-3xl font-bold ${darkMode ? 'text-white' : 'text-gray-900'} sm:text-4xl transition-colors duration-200`}>
               Why Choose Us
             </h2>
-            <p className="mt-4 text-lg text-gray-600">
+            <p className={`mt-4 text-lg ${darkMode ? 'text-gray-300' : 'text-gray-600'} transition-colors duration-200`}>
               We deliver exceptional results through our comprehensive suite of services
             </p>
           </div>
@@ -76,15 +100,23 @@ function App() {
             ].map((feature, index) => (
               <div
                 key={index}
-                className="bg-white p-6 rounded-xl shadow-sm hover:shadow-md transition-shadow"
+                className={`${
+                  darkMode ? 'bg-gray-700 hover:bg-gray-600' : 'bg-white hover:shadow-md'
+                } p-6 rounded-xl shadow-sm transition-all duration-200`}
               >
-                <div className="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center text-blue-600 mb-4">
+                <div className={`w-12 h-12 ${
+                  darkMode ? 'bg-blue-900 text-blue-400' : 'bg-blue-100 text-blue-600'
+                } rounded-lg flex items-center justify-center mb-4 transition-colors duration-200`}>
                   {feature.icon}
                 </div>
-                <h3 className="text-xl font-semibold text-gray-900 mb-2">
+                <h3 className={`text-xl font-semibold ${
+                  darkMode ? 'text-white' : 'text-gray-900'
+                } mb-2 transition-colors duration-200`}>
                   {feature.title}
                 </h3>
-                <p className="text-gray-600">
+                <p className={`${
+                  darkMode ? 'text-gray-300' : 'text-gray-600'
+                } transition-colors duration-200`}>
                   {feature.description}
                 </p>
               </div>


### PR DESCRIPTION
This PR implements the dark mode toggle functionality for the homepage as specified in PER-31.

Changes made:
- Added dark mode state management using React useState
- Implemented a dark mode toggle button with sun/moon icons
- Added dark mode styles for all sections using Tailwind classes
- Added smooth transitions for color changes
- Used CSS classes for theme switching instead of inline styles

To test:
1. Click the dark mode toggle button in the top right corner
2. Verify that all sections transition smoothly to dark mode
3. Verify that the toggle button icon changes appropriately
4. Check that all text remains readable in both modes
5. Verify that the feature cards maintain proper contrast in dark mode